### PR TITLE
Removed /etc/sysconfig/kernel insertion in dkms.

### DIFF
--- a/src/dkms
+++ b/src/dkms
@@ -938,7 +938,6 @@ etc_sysconfig_kernel_modify()
     # Make a temp directory to store files
     local temp_dir_name=$(mktemp_or_die -d $tmp_location/dkms.XXXXXX)
     if [[ $1 = add ]]; then
-        . /etc/sysconfig/kernel
         for m in "${dest_module_name[@]}"; do
             for l in "${INITRD_MODULES}"; do
                 [[ $m = $l ]] && continue 2


### PR DESCRIPTION
Removed <obsolete> code: including /etc/sysconfig/kernel in dkms. It's led to appearing error message while building module due to wrong alias syntax:
/etc/sysconfig/kernel: line 7: alias: appassure_vss0: not found
/etc/sysconfig/kernel: line 7: alias: appassure-vss: not found
Could't find purpose of this codeline, so just removed it.
V1 ID: D-27823